### PR TITLE
Update assets directory path in wrangler.jsonc

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -10,7 +10,7 @@
   "assets": {
     "not_found_handling": "single-page-application",
     "binding": "ASSETS",
-    "directory": "/assets"
+    "directory": "./public/"
   },
   "observability": {
     "enabled": true


### PR DESCRIPTION
Change the assets directory path to point to the `./public/` folder for correct asset handling.